### PR TITLE
Bug 003 double load of prov webpage causes crash

### DIFF
--- a/front/web-demo/src/prov/prov.js
+++ b/front/web-demo/src/prov/prov.js
@@ -159,7 +159,6 @@ function handleSec0Response() {
             if (message.sec_ver == 0 && message.sec0.sr.status==0) {
                 console.log("Non-secure session granted.");
                 provState = provStates.READY;
-                startScan();
 
                 // In the case of multiple auto-rise of provisioning page,
                 // we want the separate webpages to work together to issue

--- a/front/web-demo/src/prov/prov.js
+++ b/front/web-demo/src/prov/prov.js
@@ -145,7 +145,7 @@ function requestSec0Session() {
     var buffer = pbf.finish();
 
     // Issue sec0 protocomm request to the server
-    sendProtocommRequest(buffer, "POST", sessionUri, handleSec0Response, true, 2000);
+    sendProtocommRequest(buffer, "POST", sessionUri, handleSec0Response, true, 4000);
 }
 
 function handleSec0Response() {

--- a/front/web-demo/src/prov/prov.js
+++ b/front/web-demo/src/prov/prov.js
@@ -145,7 +145,7 @@ function requestSec0Session() {
     var buffer = pbf.finish();
 
     // Issue sec0 protocomm request to the server
-    sendProtocommRequest(buffer, "POST", sessionUri, handleSec0Response, true, 4000);
+    sendProtocommRequest(buffer, "POST", sessionUri, handleSec0Response, true, 5000);
 }
 
 function handleSec0Response() {


### PR DESCRIPTION
Fixes #2 
Fixes #7 

The prov.js JavaScript now checks the scan status first before issuing a scan request.  There is still possibility for sequencing issues here, but no longer in a way that can cause crash.  See discussion in #2.

To verify the fix, the following procedure was used:
- Captive portal disabled
- Device power cycled prior to every test in order to erase any latent scan results
- Six browser tabs preloaded to http://192.168.4.1/prov
- Rejoin provisioning network with PC after device is power cycled
- Refresh all six browser tabs in rapid succession

This test was repeated 10 times with the following results.
- All 10 passed with the exception of the 5th round, in which the 3rd browser window experienced a timeout on its sec0 session request. Decided that this was a minor issue and further increased the timeout.
- On 3 of the rounds, double-scan occurred thus causing double-delay for the scan results, but without other negative results.
- On 3 of the rounds, the 6th window experienced an extremely long delay (~110 seconds) before properly loading.  This is because the initial HTTP requests for the JavaScript and CSS fail/timeout while the HTTP server is blocked for the scan operation.  Firefox eventually corrects this, but not until a very long timeout.  The fundamental problem is the blocking nature of the scan operation.  It is not worth converting to a non-blocking operation to account for this stress case.