### PR TITLE
Fix race condition

### DIFF
--- a/front/web-demo/src/prov/prov.js
+++ b/front/web-demo/src/prov/prov.js
@@ -531,7 +531,7 @@ function handleShutdownProvRepsonse() {
         var resp = JSON.parse(this.responseText);
         if (resp.status === customStatusStrings[customStatus.SUCCESS]) {
             console.log("Provisioning manager shut down");
-            getHomepageUrl();
+            setTimeout(getHomepageUrl, 1000);
         } else {
             console.log("Shutdown prov command failed with status: " + resp.status);
         }


### PR DESCRIPTION
Added 1 second delay between "shutdown prov" and "get homepage" commands in the JavaScript.  This should ensure the captive portal is shut down before requesting the homepage.